### PR TITLE
Change Insect API to allow correct shared_ptr handle.

### DIFF
--- a/course/include/ant.h
+++ b/course/include/ant.h
@@ -13,7 +13,7 @@ namespace {
 
 class Ant : public Insect {
     public:
-        Ant(const std::shared_ptr<Cell>& cell);
+        Ant();
         void RunRound();
         InsectType GetInsectType();
 

--- a/course/include/insect.h
+++ b/course/include/insect.h
@@ -15,13 +15,14 @@ class Cell;
 // and defines the methods that must be implemented by every insect.
 // We need the enable_shared_from_this ineritance to pass the instance's reference when moving
 // to a new cell.
-class Insect {
+class Insect : public std::enable_shared_from_this<Insect>{
     public:
         // Simulates a round.
         virtual void RunRound() = 0;
         void Die();
         void SetRoundResultsCallback(std::function<void(InsectCallbackMetrics&)> callback);
         std::shared_ptr<Cell> GetCell();
+        void SetCell(const std::shared_ptr<Cell>& cell);
 
     protected:
         // Making these virtual allows to easily change the insect behaviour if

--- a/course/src/ant.cc
+++ b/course/src/ant.cc
@@ -4,9 +4,7 @@
 namespace ekumen {
 namespace simulation {
 
-Ant::Ant(const std::shared_ptr<Cell>& cell) {
-    this->cell = cell;
-    cell->Occupy(GetThisPtr());
+Ant::Ant() {
     metrics.SetInsectType(Ant::GetInsectType());
     rounds_until_breeding = GetRequiredRoundsToBreed();
 }
@@ -39,7 +37,9 @@ uint32_t Ant::GetRequiredRoundsToBreed() {
 }
 
 std::shared_ptr<Insect> Ant::GetNewborn(const std::shared_ptr<Cell>& cell) {
-    return std::make_shared<Ant>(cell);
+    auto newborn = std::make_shared<Ant>();
+    newborn->SetCell(cell);
+    return newborn;
 }
 
 std::shared_ptr<Cell> Ant::WhereCanIEat() {
@@ -47,7 +47,7 @@ std::shared_ptr<Cell> Ant::WhereCanIEat() {
 }
 
 std::shared_ptr<Insect> Ant::GetThisPtr() {
-    return std::make_shared<Ant>(*this);
+    return shared_from_this();
 }
 }  // namespace simulation
 }  // namespace ekumen

--- a/course/src/insect.cc
+++ b/course/src/insect.cc
@@ -9,6 +9,18 @@
 namespace ekumen {
 namespace simulation {
 
+void Insect::SetCell(const std::shared_ptr<Cell>& cell) {
+    if (!cell) {
+        throw std::invalid_argument("Null pointer passed to SetCell().");
+    }
+    // This method only should be called once upon construction.
+    if (this->cell) {
+        throw std::invalid_argument("Cell already set up before calling SetCell().");
+    }
+    this->cell = cell;
+    cell->Occupy(GetThisPtr());
+}
+
 void Insect::Die() {
     cell->Free();
     is_dead = true;

--- a/course/test/src/Ant_TEST.cc
+++ b/course/test/src/Ant_TEST.cc
@@ -13,28 +13,33 @@ namespace simulation {
 namespace test {
 namespace {
 
+using insect_ptr = std::shared_ptr<Insect>;
+
 GTEST_TEST(AntTest, OccupiedCellOnInitialization) {
   std::shared_ptr<Cell> cell(new Cell());
-  Ant ant(cell);
+  insect_ptr ant(new Ant());
+  ant->SetCell(cell);
   EXPECT_FALSE(cell->IsFree());
 }
 
 GTEST_TEST(AntTest, CallbackAssignedCorrectly) {
   std::shared_ptr<Cell> cell(new Cell());
-  Ant ant = Ant(cell);
+  insect_ptr ant(new Ant());
+  ant->SetCell(cell);
   bool lambda_called{false};
   auto callback = [&lambda_called](InsectCallbackMetrics& metrics) {
         lambda_called = true;
   };
-  ant.SetRoundResultsCallback(callback);
-  ant.RunRound();
+  ant->SetRoundResultsCallback(callback);
+  ant->RunRound();
 
   EXPECT_TRUE(lambda_called);
 }
 
 GTEST_TEST(AntTest, IsAliveOnInit) {
   std::shared_ptr<Cell> cell(new Cell());
-  Ant ant = Ant(cell);
+  insect_ptr ant(new Ant());
+  ant->SetCell(cell);
   bool is_dead{false};
   auto callback = [&is_dead](InsectCallbackMetrics& metrics) {
         if (metrics.IsDead()) {
@@ -42,14 +47,15 @@ GTEST_TEST(AntTest, IsAliveOnInit) {
         }
   };
 
-  ant.SetRoundResultsCallback(callback);
-  ant.RunRound();
+  ant->SetRoundResultsCallback(callback);
+  ant->RunRound();
   EXPECT_FALSE(is_dead);
 }
 
 GTEST_TEST(AntTest, IsDeadWhenToldToDie) {
   std::shared_ptr<Cell> cell(new Cell());
-  Ant ant = Ant(cell);
+  insect_ptr ant(new Ant());
+  ant->SetCell(cell);
   bool is_dead{false};
   auto callback = [&is_dead](InsectCallbackMetrics& metrics) {
         if (metrics.IsDead()) {
@@ -57,11 +63,11 @@ GTEST_TEST(AntTest, IsDeadWhenToldToDie) {
         }
   };
 
-  ant.SetRoundResultsCallback(callback);
-  ant.RunRound();
+  ant->SetRoundResultsCallback(callback);
+  ant->RunRound();
   EXPECT_FALSE(is_dead);
-  ant.Die();
-  ant.RunRound();
+  ant->Die();
+  ant->RunRound();
   EXPECT_TRUE(is_dead);
 }
 
@@ -70,9 +76,10 @@ GTEST_TEST(AntTest, AntMovedToOtherCell) {
   SurroundingCells surr({free_cell, free_cell, free_cell, free_cell});
   std::shared_ptr<Cell> center_cell(new Cell());
   center_cell->SetSurroundingCells(surr);
-  Ant moving_ant(center_cell);
+  insect_ptr moving_ant(new Ant());
+  moving_ant->SetCell(center_cell);
 
-  moving_ant.RunRound();
+  moving_ant->RunRound();
 
   EXPECT_FALSE(free_cell->IsFree());
   EXPECT_TRUE(center_cell->IsFree());
@@ -80,14 +87,16 @@ GTEST_TEST(AntTest, AntMovedToOtherCell) {
 
 GTEST_TEST(AntTest, AntDidntMoveWhenCantMove) {
   std::shared_ptr<Cell> occupied_cell(new Cell());
-  Ant occupying_ant(occupied_cell);
+  insect_ptr occupying_ant(new Ant());
+  occupying_ant->SetCell(occupied_cell);
   // We'll surround the cell with an occupied cell, so that the ant can't move.
   SurroundingCells surr({occupied_cell, occupied_cell, occupied_cell, occupied_cell});
   std::shared_ptr<Cell> surrounded_cell(new Cell());
   surrounded_cell->SetSurroundingCells(surr);
-  Ant surrounded_ant(surrounded_cell);
+  insect_ptr surrounded_ant(new Ant());
+  surrounded_ant->SetCell(surrounded_cell);
 
-  EXPECT_EQ(surrounded_ant.GetCell().get(), surrounded_cell.get());
+  EXPECT_EQ(surrounded_ant->GetCell().get(), surrounded_cell.get());
 }
 
 GTEST_TEST(AntTest, BreedAfter3RoundsNotBefore) {
@@ -98,20 +107,21 @@ GTEST_TEST(AntTest, BreedAfter3RoundsNotBefore) {
   SurroundingCells surr_free({cell, cell, cell, cell});
   cell->SetSurroundingCells(surr);
   free_cell->SetSurroundingCells(surr_free);
-  Ant ant(cell);
+  insect_ptr ant(new Ant());
+  ant->SetCell(cell);
   bool has_bred{false};
   auto callback = [&has_bred](InsectCallbackMetrics& metrics) {
         if (metrics.HasBred()) {
           has_bred = true;
         }
   };
-  ant.SetRoundResultsCallback(callback);
+  ant->SetRoundResultsCallback(callback);
 
-  ant.RunRound();
+  ant->RunRound();
   EXPECT_FALSE(has_bred);
-  ant.RunRound();
+  ant->RunRound();
   EXPECT_FALSE(has_bred);
-  ant.RunRound();
+  ant->RunRound();
   EXPECT_TRUE(has_bred);
 }
 }  // namespace


### PR DESCRIPTION
## Context
Before this PR, an incorrect handling of a shared pointer to ```this``` was being used.

As a result, this led to unexpected behaviors when using the Ant class with other classes.

## Purpose
This PR solves the wrong handling of the shared pointer to ```this``` by using ```shared_from_this()``` provided by the class ```enable_shared_from_this```.

## Notes
There are two consequences implied by these changes:
 - The insects will have to be managed as shared pointers. Using a reference directly to an insect instance can lead to unexpected behavior.
- A setter function (```SetCell()```) will have to be called immediately after the constructor, which sets the corresponding cell where the insect lives. This can't be done during the construction phase because ```this``` pointer is undefined during the construction of an instance.

### Example of wrong usage:
```
Ant ant(cell);
ant.RunRound();
```

### Example of correct usage:
```
std::shared_ptr<Ant> ant(new Ant());
ant->SetCell(cell);
```